### PR TITLE
feat: add Radio and Tooltip components with demos

### DIFF
--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -77,6 +77,8 @@ const MENU_ITEMS: MenuItem[] = [
             { key: 'icon', label: 'Icon 图标' },
             { key: 'select', label: 'Select 选择器' },
             { key: 'checkbox', label: 'Checkbox 多选框' },
+            { key: 'radio', label: 'Radio 单选框', isNew: true },
+            { key: 'tooltip', label: 'Tooltip 气泡提示', isNew: true },
             { key: 'tabs', label: 'Tabs 标签页' },
             { key: 'footer', label: 'Footer 页脚' },
             { key: 'codeblock', label: 'CodeBlock 代码高亮' },

--- a/demo/ComponentPage.tsx
+++ b/demo/ComponentPage.tsx
@@ -17,6 +17,8 @@ import FooterDemo from './components/Footer';
 import IconDemo from './components/Icon/IconDemo';
 import TabsDemo from './components/Tabs';
 import CheckboxDemo from './components/Checkbox';
+import RadioDemo from './components/Radio';
+import TooltipDemo from './components/Tooltip';
 import CodeBlockDemo from './components/CodeBlock';
 import LoadingDemo from './components/Loading/LoadingDemo';
 import TableDemo from './components/Table/TableDemo';
@@ -1313,6 +1315,14 @@ export const PAGE_INFO: Record<string, { title: string; desc: string }> = {
         title: 'Checkbox 多选框',
         desc: '多选框组件 — 支持受控/非受控、水平/垂直排列、三种尺寸、禁用单项或全部禁用',
     },
+    radio: {
+        title: 'Radio 单选框',
+        desc: '单选框组件 — 支持受控/非受控、水平/垂直排列、三种尺寸、禁用单项或全部禁用',
+    },
+    tooltip: {
+        title: 'Tooltip 气泡提示',
+        desc: '气泡提示组件 — 支持 12 个方向、hover/click/focus 三种触发，default/island 两种风格，bordered 边框可配置',
+    },
     codeblock: {
         title: 'CodeBlock 代码高亮',
         desc: '代码高亮组件 — 语法高亮显示，支持自定义样式和类名',
@@ -1348,6 +1358,8 @@ const PAGES: Record<string, React.FC> = {
     select: SelectDemo,
     tabs: TabsDemo,
     checkbox: CheckboxDemo,
+    radio: RadioDemo,
+    tooltip: TooltipDemo,
     codeblock: CodeBlockDemo,
     loading: LoadingDemo,
     table: TableDemo,

--- a/demo/components/Radio/index.tsx
+++ b/demo/components/Radio/index.tsx
@@ -1,0 +1,138 @@
+import React, { useState } from 'react';
+import { Radio } from '../../../src';
+import {
+    labelStyle,
+    ApiTable,
+    CodeBlock,
+    ApiRow,
+    sectionStyle,
+    sectionTitleStyle,
+    tagStyle,
+    demoBoxStyle,
+} from '../../tools';
+
+const RADIO_API: ApiRow[] = [
+    { prop: 'options', desc: '选项列表', type: 'RadioOption[]', defaultVal: '-', required: true },
+    { prop: 'value', desc: '受控选中值', type: 'string | number', defaultVal: '-' },
+    { prop: 'defaultValue', desc: '默认选中值', type: 'string | number', defaultVal: '-' },
+    { prop: 'size', desc: '尺寸', type: "'small' | 'middle' | 'large'", defaultVal: "'middle'" },
+    { prop: 'disabled', desc: '禁用全部选项', type: 'boolean', defaultVal: 'false' },
+    { prop: 'direction', desc: '排列方向', type: "'horizontal' | 'vertical'", defaultVal: "'horizontal'" },
+    { prop: 'onChange', desc: '选中值变化回调', type: '(value: string | number) => void', defaultVal: '-' },
+    { prop: 'className', desc: '自定义类名', type: 'string', defaultVal: '-' },
+    { prop: 'style', desc: '自定义样式', type: 'React.CSSProperties', defaultVal: '-' },
+];
+
+const seasonOptions = [
+    { label: '🌸 春天', value: 'spring' },
+    { label: '☀️ 夏天', value: 'summer' },
+    { label: '🍁 秋天', value: 'autumn' },
+    { label: '❄️ 冬天', value: 'winter' },
+];
+
+const fruitOptions = [
+    { label: '🍎 苹果', value: 'apple' },
+    { label: '🍊 橙子', value: 'orange' },
+    { label: '🍑 桃子', value: 'peach' },
+    { label: '🍐 梨子', value: 'pear', disabled: true },
+    { label: '🍒 樱桃', value: 'cherry' },
+];
+
+const timeOptions = [
+    { label: '🌅 早晨', value: 'morning' },
+    { label: '🌞 中午', value: 'noon' },
+    { label: '🌇 傍晚', value: 'evening' },
+    { label: '🌙 深夜', value: 'night' },
+];
+
+const RadioDemo: React.FC = () => {
+    const [selected1, setSelected1] = useState<string | number>('spring');
+    const [selected2, setSelected2] = useState<string | number>('');
+    const [selected3, setSelected3] = useState<string | number>('noon');
+
+    return (
+        <div style={sectionStyle}>
+            <div style={sectionTitleStyle}>
+                Radio <span style={tagStyle}>单选框</span>
+            </div>
+
+            <div style={labelStyle}>水平排列（受控）— 支持方向键 ↑↓←→ 切换</div>
+            <div style={{ marginBottom: 8, fontSize: 13, color: '#a08060' }}>
+                已选中:{' '}
+                <span style={{ color: '#19c8b9', fontWeight: 600 }}>
+                    {seasonOptions.find((o) => o.value === selected1)?.label ?? '无'}
+                </span>
+            </div>
+            <div style={demoBoxStyle}>
+                <Radio options={seasonOptions} value={selected1} onChange={setSelected1} style={{ gap: 20 }} />
+            </div>
+
+            <div style={labelStyle}>垂直排列 + 含禁用选项</div>
+            <div style={demoBoxStyle}>
+                <Radio
+                    options={fruitOptions}
+                    value={selected2}
+                    onChange={setSelected2}
+                    direction="vertical"
+                    style={{ gap: 12 }}
+                />
+            </div>
+
+            <div style={labelStyle}>三种尺寸对比</div>
+            <div style={demoBoxStyle}>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+                    <Radio options={timeOptions} defaultValue="morning" size="small" />
+                    <Radio options={timeOptions} defaultValue="noon" size="middle" />
+                    <Radio options={timeOptions} defaultValue="night" size="large" />
+                </div>
+            </div>
+
+            <div style={labelStyle}>3D 按键感 — 点击体验下压反馈</div>
+            <div style={{ marginBottom: 8, fontSize: 13, color: '#a08060' }}>
+                已选中:{' '}
+                <span style={{ color: '#19c8b9', fontWeight: 600 }}>
+                    {timeOptions.find((o) => o.value === selected3)?.label ?? '无'}
+                </span>
+            </div>
+            <div style={demoBoxStyle}>
+                <Radio options={timeOptions} value={selected3} onChange={setSelected3} size="large" />
+            </div>
+
+            <div style={labelStyle}>全部禁用</div>
+            <div style={demoBoxStyle}>
+                <Radio options={seasonOptions} defaultValue="winter" disabled />
+            </div>
+
+            <CodeBlock
+                code={`import React, { useState } from 'react';
+import { Radio } from 'animal-island-ui';
+
+const options = [
+    { label: '🌸 春天', value: 'spring' },
+    { label: '☀️ 夏天', value: 'summer' },
+    { label: '🍁 秋天', value: 'autumn' },
+    { label: '❄️ 冬天', value: 'winter' },
+];
+
+const App = () => {
+    const [value, setValue] = useState('spring');
+    return (
+        <div>
+            {/* 非受控 */}
+            <Radio options={options} defaultValue="spring" />
+            {/* 受控 */}
+            <Radio options={options} value={value} onChange={setValue} />
+            {/* 垂直排列 */}
+            <Radio options={options} direction="vertical" />
+        </div>
+    );
+};
+
+export default App;`}
+            />
+            <ApiTable rows={RADIO_API} />
+        </div>
+    );
+};
+
+export default RadioDemo;

--- a/demo/components/Tooltip/index.tsx
+++ b/demo/components/Tooltip/index.tsx
@@ -1,0 +1,326 @@
+import React from 'react';
+import { Tooltip, Button } from '../../../src';
+import {
+    labelStyle,
+    ApiTable,
+    CodeBlock,
+    ApiRow,
+    sectionStyle,
+    sectionTitleStyle,
+    tagStyle,
+    demoBoxStyle,
+} from '../../tools';
+
+const TOOLTIP_API: ApiRow[] = [
+    { prop: 'title', desc: '提示内容，支持多行（可用 \\n 或 <br/> 换行）', type: 'ReactNode', defaultVal: '-', required: true },
+    { prop: 'placement', desc: '位置', type: "'top' | 'top-start' | 'top-end' | 'bottom' | 'bottom-start' | 'bottom-end' | 'left' | 'left-start' | 'left-end' | 'right' | 'right-start' | 'right-end'", defaultVal: "'top'" },
+    { prop: 'trigger', desc: '触发方式', type: "'hover' | 'focus' | 'click'", defaultVal: "'hover'" },
+    { prop: 'variant', desc: '视觉风格', type: "'default' | 'island'", defaultVal: "'default'" },
+    { prop: 'bordered', desc: '是否显示边框（含箭头描边）', type: 'boolean', defaultVal: 'true' },
+    { prop: 'children', desc: '触发元素', type: 'ReactElement', defaultVal: '-', required: true },
+    { prop: 'className', desc: '自定义类名', type: 'string', defaultVal: '-' },
+    { prop: 'style', desc: '自定义样式', type: 'React.CSSProperties', defaultVal: '-' },
+];
+
+const leftColStyle: React.CSSProperties = {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 12,
+    alignItems: 'flex-start',
+};
+
+const rightColStyle: React.CSSProperties = {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 12,
+    alignItems: 'flex-end',
+};
+
+const placementRowStyle: React.CSSProperties = {
+    display: 'flex',
+    gap: 12,
+};
+
+const placementBoxStyle: React.CSSProperties = {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: 12,
+};
+
+const centerMarkStyle: React.CSSProperties = {
+    width: 80,
+    height: 80,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: 16,
+    background: '#f0e8d8',
+    color: '#a0936e',
+    fontSize: 12,
+    fontWeight: 600,
+    textAlign: 'center',
+    lineHeight: 1.3,
+    flexShrink: 0,
+};
+
+const leftTooltipTitle = (label: string) => (
+    <>
+        {label}
+        <br />
+        箭头在右侧
+        <br />
+        指向触发按钮
+    </>
+);
+
+const rightTooltipTitle = (label: string) => (
+    <>
+        {label}
+        <br />
+        箭头在左侧
+        <br />
+        指向触发按钮
+    </>
+);
+
+const TooltipDemo: React.FC = () => {
+    return (
+        <div style={sectionStyle}>
+            <div style={sectionTitleStyle}>
+                Tooltip <span style={tagStyle}>气泡提示</span>
+            </div>
+
+            <div style={labelStyle}>基础用法 — hover 触发</div>
+            <div style={demoBoxStyle}>
+                <div style={{ display: 'flex', gap: 16, alignItems: 'center', flexWrap: 'wrap' }}>
+                    <Tooltip title="提示文字">
+                        <Button type="primary" size="small">Hover 我</Button>
+                    </Tooltip>
+                </div>
+            </div>
+
+            <div style={labelStyle}>风格 — island 动森不规则气泡</div>
+            <div style={{ ...demoBoxStyle, overflow: 'visible' }}>
+                <div style={{ display: 'flex', gap: 24, alignItems: 'center', flexWrap: 'wrap' }}>
+                    <Tooltip title="标准矩形气泡" placement="top">
+                        <Button size="small">default</Button>
+                    </Tooltip>
+                    <Tooltip title="无边框矩形" placement="top" bordered={false}>
+                        <Button size="small">default 无边框</Button>
+                    </Tooltip>
+                    <Tooltip
+                        variant="island"
+                        bordered
+                        placement="top"
+                        title={
+                            <>
+                                钓到<span style={{ color: '#d4834a' }}>石头</span>了！
+                                <br />
+                                竟然连这种都能钓起来…
+                            </>
+                        }
+                    >
+                        <Button size="small">island 有边框</Button>
+                    </Tooltip>
+                    <Tooltip
+                        variant="island"
+                        bordered={false}
+                        placement="top"
+                        title={
+                            <>
+                                无边框有机气泡
+                                <br />
+                                圆点指示方向
+                            </>
+                        }
+                    >
+                        <Button size="small">island 无边框</Button>
+                    </Tooltip>
+                </div>
+            </div>
+
+            <div style={labelStyle}>12 个方向</div>
+            <div style={{ ...demoBoxStyle, overflow: 'visible' }}>
+                <div style={placementBoxStyle}>
+                    <div style={placementRowStyle}>
+                        <Tooltip title="top-start" placement="top-start">
+                            <Button size="small">top-start</Button>
+                        </Tooltip>
+                        <Tooltip title="top" placement="top">
+                            <Button size="small">top</Button>
+                        </Tooltip>
+                        <Tooltip title="top-end" placement="top-end">
+                            <Button size="small">top-end</Button>
+                        </Tooltip>
+                    </div>
+
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 48 }}>
+                        <div style={leftColStyle}>
+                            <Tooltip title={leftTooltipTitle('left-start')} placement="left-start">
+                                <Button size="small">left-start</Button>
+                            </Tooltip>
+                            <Tooltip title={leftTooltipTitle('left')} placement="left">
+                                <Button size="small">left</Button>
+                            </Tooltip>
+                            <Tooltip title={leftTooltipTitle('left-end')} placement="left-end">
+                                <Button size="small">left-end</Button>
+                            </Tooltip>
+                        </div>
+
+                        <div style={centerMarkStyle}>
+                            12<br />placements
+                        </div>
+
+                        <div style={rightColStyle}>
+                            <Tooltip title={rightTooltipTitle('right-start')} placement="right-start">
+                                <Button size="small">right-start</Button>
+                            </Tooltip>
+                            <Tooltip title={rightTooltipTitle('right')} placement="right">
+                                <Button size="small">right</Button>
+                            </Tooltip>
+                            <Tooltip title={rightTooltipTitle('right-end')} placement="right-end">
+                                <Button size="small">right-end</Button>
+                            </Tooltip>
+                        </div>
+                    </div>
+
+                    <div style={placementRowStyle}>
+                        <Tooltip title="bottom-start" placement="bottom-start">
+                            <Button size="small">bottom-start</Button>
+                        </Tooltip>
+                        <Tooltip title="bottom" placement="bottom">
+                            <Button size="small">bottom</Button>
+                        </Tooltip>
+                        <Tooltip title="bottom-end" placement="bottom-end">
+                            <Button size="small">bottom-end</Button>
+                        </Tooltip>
+                    </div>
+                </div>
+            </div>
+
+            <div style={labelStyle}>触发方式 — click</div>
+            <div style={demoBoxStyle}>
+                <Tooltip title="点击触发，再点关闭" trigger="click" placement="bottom">
+                    <Button size="small">Click 触发</Button>
+                </Tooltip>
+            </div>
+
+            <div style={labelStyle}>触发方式 — focus</div>
+            <div style={demoBoxStyle}>
+                <Tooltip title="聚焦时显示" trigger="focus" placement="right">
+                    <input
+                        type="text"
+                        placeholder="点击输入框聚焦"
+                        style={{
+                            padding: '8px 16px',
+                            borderRadius: 50,
+                            border: '2px solid #c4b89e',
+                            background: 'rgb(247, 243, 223)',
+                            fontFamily: 'inherit',
+                            fontSize: 14,
+                            color: '#725d42',
+                            outline: 'none',
+                        }}
+                    />
+                </Tooltip>
+            </div>
+
+            <div style={labelStyle}>多行内容</div>
+            <div style={demoBoxStyle}>
+                <div style={{ display: 'flex', gap: 16, flexWrap: 'wrap' }}>
+                    <Tooltip
+                        title={
+                            <>
+                                第一行文字
+                                <br />
+                                第二行文字
+                                <br />
+                                第三行文字 🍃
+                            </>
+                        }
+                        placement="top"
+                    >
+                        <Button size="small">多行 JSX</Button>
+                    </Tooltip>
+
+                    <Tooltip
+                        title={"第一行\n第二行\n第三行 🌿"}
+                        placement="top"
+                    >
+                        <Button size="small">换行符 \n</Button>
+                    </Tooltip>
+
+                    <Tooltip
+                        title="这是一段比较长的提示文字，用来测试 Tooltip 的自动换行效果。当文字超过最大宽度时会自动换行。"
+                        placement="top"
+                    >
+                        <Button size="small">自动换行长文本</Button>
+                    </Tooltip>
+                </div>
+            </div>
+
+            <CodeBlock
+                code={`import React from 'react';
+import { Tooltip, Button } from 'animal-island-ui';
+
+const App = () => {
+    return (
+        <div>
+            {/* 基础用法 */}
+            <Tooltip title="提示文字">
+                <Button>Hover 我</Button>
+            </Tooltip>
+
+            {/* 动森 island 风格 — bordered 默认 true，箭头更清晰 */}
+            <Tooltip variant="island" bordered title="有边框有机气泡">
+                <Button>Island</Button>
+            </Tooltip>
+            <Tooltip variant="island" bordered={false} title="无边框 · 圆点指示">
+                <Button>Island 无边框</Button>
+            </Tooltip>
+
+            {/* 12 个方向 */}
+            <Tooltip title="我在上方" placement="top">
+                <Button>Top</Button>
+            </Tooltip>
+            <Tooltip title="我在左下方" placement="bottom-start">
+                <Button>Bottom-Start</Button>
+            </Tooltip>
+
+            {/* Click 触发 */}
+            <Tooltip title="点击触发" trigger="click">
+                <Button>Click</Button>
+            </Tooltip>
+
+            {/* Focus 触发 */}
+            <Tooltip title="聚焦显示" trigger="focus">
+                <input placeholder="点击聚焦" />
+            </Tooltip>
+
+            {/* 多行内容 */}
+            <Tooltip
+                title={
+                    <>
+                        第一行
+                        <br />
+                        第二行
+                        <br />
+                        第三行 🍃
+                    </>
+                }
+            >
+                <Button>多行</Button>
+            </Tooltip>
+        </div>
+    );
+};
+
+export default App;`}
+            />
+            <ApiTable rows={TOOLTIP_API} />
+        </div>
+    );
+};
+
+export default TooltipDemo;

--- a/demo/pageInfo.ts
+++ b/demo/pageInfo.ts
@@ -60,6 +60,14 @@ export const PAGE_INFO: Record<string, { title: string; desc: string }> = {
         title: 'Checkbox 多选框',
         desc: '多选框组件 — 支持受控/非受控、水平/垂直排列、三种尺寸、禁用单项或全部禁用',
     },
+    radio: {
+        title: 'Radio 单选框',
+        desc: '单选框组件 — 支持受控/非受控、水平/垂直排列、三种尺寸、禁用单项或全部禁用',
+    },
+    tooltip: {
+        title: 'Tooltip 气泡提示',
+        desc: '气泡提示组件 — 支持 12 个方向、hover/click/focus 三种触发，default/island 两种风格，bordered 边框可配置',
+    },
     codeblock: {
         title: 'CodeBlock 代码高亮',
         desc: '代码高亮组件 — 语法高亮显示，支持自定义样式和类名',

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -1,0 +1,194 @@
+import React, { useState, useCallback, useRef, useMemo, useEffect } from 'react';
+import styles from './radio.module.less';
+import classNames from 'classnames';
+
+export type RadioSize = 'small' | 'middle' | 'large';
+
+export interface RadioOption {
+    /** 选项标签 */
+    label: React.ReactNode;
+    /** 选项值 */
+    value: string | number;
+    /** 是否禁用该选项 */
+    disabled?: boolean;
+}
+
+export interface RadioProps {
+    /** 选中的值（受控） */
+    value?: string | number;
+    /** 默认选中的值 */
+    defaultValue?: string | number;
+    /** 选项列表 */
+    options: RadioOption[];
+    /** 尺寸 */
+    size?: RadioSize;
+    /** 禁用全部 */
+    disabled?: boolean;
+    /** 布局方向 */
+    direction?: 'horizontal' | 'vertical';
+    /** 变化回调 */
+    onChange?: (value: string | number) => void;
+    /** 自定义类名 */
+    className?: string;
+    /** 自定义样式 */
+    style?: React.CSSProperties;
+}
+
+export const Radio: React.FC<RadioProps> = ({
+    value,
+    defaultValue,
+    options,
+    size = 'middle',
+    disabled = false,
+    direction = 'horizontal',
+    onChange,
+    className,
+    style,
+}) => {
+    const [innerValue, setInnerValue] = useState<string | number | undefined>(defaultValue);
+    const isControlled = value !== undefined;
+    const checkedValue = isControlled ? value : innerValue;
+
+    const groupRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        const idx = options.findIndex((o) => o.value === checkedValue);
+        if (idx >= 0) setFocusedIndex(idx);
+    }, [checkedValue, options]);
+
+    // 当前聚焦的索引（用于 roving tabindex）
+    const [focusedIndex, setFocusedIndex] = useState<number>(() => {
+        const idx = options.findIndex((o) => o.value === checkedValue);
+        return idx >= 0 ? idx : 0;
+    });
+
+    // 获取所有可用（未禁用）选项的索引
+    const enabledIndices = useMemo(() => {
+        return options
+            .map((opt, idx) => ({ opt, idx }))
+            .filter(({ opt }) => !disabled && !opt.disabled)
+            .map(({ idx }) => idx);
+    }, [options, disabled]);
+
+    // 找到当前可用项在 enabledIndices 中的位置
+    const currentEnabledPos = useMemo(() => {
+        return enabledIndices.indexOf(focusedIndex);
+    }, [enabledIndices, focusedIndex]);
+
+    const handleChange = useCallback(
+        (optValue: string | number, optDisabled?: boolean) => {
+            if (disabled || optDisabled) return;
+            if (!isControlled) setInnerValue(optValue);
+            onChange?.(optValue);
+        },
+        [disabled, isControlled, onChange]
+    );
+
+    // 方向键导航：移动到下一个/上一个可用选项并选中
+    const handleKeyDown = useCallback(
+        (e: React.KeyboardEvent<HTMLDivElement>) => {
+            if (enabledIndices.length === 0) return;
+
+            const isHorizontal = direction === 'horizontal';
+            let nextPos = -1;
+
+            switch (e.key) {
+                case 'ArrowRight':
+                case 'ArrowDown':
+                    e.preventDefault();
+                    nextPos = (currentEnabledPos + 1) % enabledIndices.length;
+                    break;
+                case 'ArrowLeft':
+                case 'ArrowUp':
+                    e.preventDefault();
+                    nextPos = (currentEnabledPos - 1 + enabledIndices.length) % enabledIndices.length;
+                    break;
+                case 'Home':
+                    e.preventDefault();
+                    nextPos = 0;
+                    break;
+                case 'End':
+                    e.preventDefault();
+                    nextPos = enabledIndices.length - 1;
+                    break;
+                default:
+                    return;
+            }
+
+            if (nextPos >= 0) {
+                const nextIdx = enabledIndices[nextPos];
+                setFocusedIndex(nextIdx);
+                handleChange(options[nextIdx].value, options[nextIdx].disabled);
+
+                // 聚焦到对应的 radio circle
+                const circles = groupRef.current?.querySelectorAll('[data-radio-circle]');
+                (circles?.[nextIdx] as HTMLElement)?.focus();
+            }
+        },
+        [direction, enabledIndices, currentEnabledPos, options, handleChange]
+    );
+
+    return (
+        <div
+            ref={groupRef}
+            className={classNames(
+                styles.radioGroup,
+                styles[direction],
+                { [styles.groupDisabled]: disabled },
+                className
+            )}
+            style={style}
+            role="radiogroup"
+            onKeyDown={handleKeyDown}
+        >
+            {options.map((opt, idx) => {
+                const isChecked = checkedValue === opt.value;
+                const isDisabled = disabled || opt.disabled;
+                const isFocusable = idx === focusedIndex && !isDisabled;
+
+                return (
+                    <label
+                        key={String(opt.value)}
+                        className={classNames(
+                            styles.radioItem,
+                            styles[size],
+                            {
+                                [styles.checked]: isChecked,
+                                [styles.disabled]: isDisabled,
+                            }
+                        )}
+                        onClick={() => {
+                            if (!isDisabled) {
+                                setFocusedIndex(idx);
+                                handleChange(opt.value, opt.disabled);
+                            }
+                        }}
+                    >
+                        <span
+                            className={styles.circle}
+                            data-radio-circle
+                            role="radio"
+                            aria-checked={isChecked}
+                            aria-disabled={isDisabled || undefined}
+                            tabIndex={isFocusable ? 0 : -1}
+                            onFocus={() => {
+                                if (!isDisabled) setFocusedIndex(idx);
+                            }}
+                            onKeyDown={(e) => {
+                                if (e.key === ' ' || e.key === 'Enter') {
+                                    e.preventDefault();
+                                    handleChange(opt.value, opt.disabled);
+                                }
+                            }}
+                        >
+                            {isChecked && <span className={styles.dot} />}
+                        </span>
+                        <span className={styles.label}>{opt.label}</span>
+                    </label>
+                );
+            })}
+        </div>
+    );
+};
+
+Radio.displayName = 'Radio';

--- a/src/components/Radio/index.ts
+++ b/src/components/Radio/index.ts
@@ -1,0 +1,2 @@
+export { Radio } from './Radio';
+export type { RadioProps, RadioOption, RadioSize } from './Radio';

--- a/src/components/Radio/radio.module.less
+++ b/src/components/Radio/radio.module.less
@@ -1,0 +1,201 @@
+// ============================================
+// Radio — Animal Island Style (Enhanced)
+// ============================================
+@import '../../styles/variables.less';
+
+.radioGroup {
+    display: flex;
+    flex-wrap: wrap;
+    gap: @spacing-md;
+    font-family: @font-family;
+}
+
+.horizontal {
+    flex-direction: row;
+}
+
+.vertical {
+    flex-direction: column;
+    gap: @spacing-sm;
+}
+
+// ---------- Item ----------
+.radioItem {
+    display: inline-flex;
+    align-items: center;
+    gap: @spacing-sm;
+    cursor: pointer;
+    user-select: none;
+    transition: all @motion-duration-base @motion-ease;
+}
+
+// ---------- Size: small ----------
+.small {
+    .circle {
+        width: 18px;
+        height: 18px;
+        border-width: 2px;
+    }
+
+    .dot {
+        width: 8px;
+        height: 8px;
+    }
+
+    .label {
+        font-size: @font-size-sm;
+    }
+}
+
+// ---------- Size: middle (default) ----------
+.middle {
+    .circle {
+        width: 22px;
+        height: 22px;
+        border-width: 2.5px;
+    }
+
+    .dot {
+        width: 10px;
+        height: 10px;
+    }
+
+    .label {
+        font-size: @font-size-base;
+    }
+}
+
+// ---------- Size: large ----------
+.large {
+    .circle {
+        width: 28px;
+        height: 28px;
+        border-width: 3px;
+    }
+
+    .dot {
+        width: 14px;
+        height: 14px;
+    }
+
+    .label {
+        font-size: @font-size-lg;
+    }
+}
+
+// ---------- Circle ----------
+.circle {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    background: rgb(247, 243, 223);
+    border: 2.5px solid #c4b89e;
+    border-radius: 50%;
+    transition: all @motion-duration-base @motion-ease;
+    outline: none;
+
+    // focus-visible 黄色外框
+    &:focus-visible {
+        outline: 2px solid @focus-yellow;
+        outline-offset: 2px;
+    }
+}
+
+// ---------- Hover（未选中时）----------
+.radioItem:not(.disabled):not(.checked):hover {
+    .circle {
+        border-color: @primary-color;
+        transform: translateY(-1px);
+    }
+
+    .label {
+        color: #794f27;
+    }
+}
+
+// ---------- Hover（已选中时）----------
+.radioItem.checked:not(.disabled):hover {
+    .circle {
+        transform: scale(1.06);
+        box-shadow: 0 0 0 3px rgba(25, 200, 185, 0.12);
+    }
+}
+
+// ---------- Active（按下）----------
+.radioItem:not(.disabled):active {
+    .circle {
+        transform: translateY(1px) scale(0.96);
+    }
+}
+
+// ---------- Checked ----------
+.checked {
+    .circle {
+        background: @primary-color;
+        border-color: @primary-color-active;
+    }
+}
+
+// ---------- Dot（弹性 overshoot 动画）----------
+.dot {
+    display: block;
+    background: #fff;
+    border-radius: 50%;
+    animation: animal-radio-pop 0.35s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+
+@keyframes animal-radio-pop {
+    0% {
+        transform: scale(0);
+        opacity: 0;
+    }
+
+    60% {
+        transform: scale(1.35);
+    }
+
+    80% {
+        transform: scale(0.92);
+    }
+
+    100% {
+        transform: scale(1);
+        opacity: 1;
+    }
+}
+
+// ---------- Label ----------
+.label {
+    color: #725d42;
+    font-weight: 500;
+    letter-spacing: 0.01em;
+    transition: color @motion-duration-fast;
+}
+
+.checked .label {
+    color: #794f27;
+    font-weight: 600;
+}
+
+// ---------- Disabled ----------
+.disabled {
+    cursor: not-allowed;
+    opacity: 0.55;
+
+    .circle {
+        background: #f0ece2;
+        border-color: #d4c9b4;
+        transform: none !important;
+        box-shadow: none !important;
+    }
+
+    .label {
+        color: #c4b89e;
+    }
+}
+
+.groupDisabled .radioItem {
+    cursor: not-allowed;
+}

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -1,0 +1,174 @@
+import React, { useState, useRef, useCallback, useEffect, useId } from 'react';
+import styles from './tooltip.module.less';
+import classNames from 'classnames';
+
+export type TooltipPlacement =
+    | 'top'
+    | 'top-start'
+    | 'top-end'
+    | 'bottom'
+    | 'bottom-start'
+    | 'bottom-end'
+    | 'left'
+    | 'left-start'
+    | 'left-end'
+    | 'right'
+    | 'right-start'
+    | 'right-end';
+
+export type TooltipTrigger = 'hover' | 'focus' | 'click';
+
+/** default 标准矩形；island 动森不规则有机气泡（与 Modal 同款 clip-path） */
+export type TooltipVariant = 'default' | 'island';
+
+const ISLAND_CLIP_PATH =
+    'M0.501,0.005 L0.501,0.005 L0.523,0.005 L0.549,0.006 C0.704,0.01,0.796,0.017,0.825,0.027 L0.827,0.028 C0.872,0.045,0.939,0.044,0.978,0.17 C1,0.254,1,0.365,0.99,0.505 L0.988,0.513 C0.979,0.558,0.971,0.598,0.965,0.633 C0.956,0.689,0.979,0.77,0.964,0.865 C0.953,0.928,0.921,0.966,0.869,0.979 C0.821,0.986,0.773,0.992,0.726,0.995 L0.712,0.996 L0.694,0.997 C0.648,1,0.586,1,0.507,1 L0.501,1 L0.464,1 C0.385,1,0.325,0.998,0.283,0.995 C0.234,0.992,0.184,0.987,0.133,0.979 C0.081,0.966,0.05,0.928,0.039,0.865 C0.023,0.77,0.047,0.689,0.037,0.633 C0.031,0.595,0.023,0.552,0.013,0.505 C-0.006,0.365,-0.002,0.254,0.024,0.17 C0.064,0.045,0.13,0.045,0.174,0.028 L0.175,0.028 C0.204,0.017,0.303,0.009,0.474,0.005 L0.501,0.005';
+
+const ISLAND_BG = 'rgb(247, 243, 223)';
+const ISLAND_STROKE = '#c4b89e';
+
+const IslandClipDef: React.FC<{ id: string }> = ({ id }) => (
+    <svg style={{ position: 'absolute', width: 0, height: 0 }} aria-hidden>
+        <clipPath id={id} clipPathUnits="objectBoundingBox">
+            <path d={ISLAND_CLIP_PATH} />
+        </clipPath>
+    </svg>
+);
+
+/** SVG 沿有机路径 fill + stroke，边框贴合不规则轮廓 */
+const IslandShapeSvg: React.FC = () => (
+    <svg
+        className={styles.islandSvg}
+        viewBox="0 0 1 1"
+        preserveAspectRatio="none"
+        aria-hidden
+    >
+        <path
+            d={ISLAND_CLIP_PATH}
+            fill={ISLAND_BG}
+            stroke={ISLAND_STROKE}
+            strokeWidth={2}
+            vectorEffect="non-scaling-stroke"
+            strokeLinejoin="round"
+        />
+    </svg>
+);
+
+export interface TooltipProps {
+    /** 提示内容，支持多行（可用 \n 或 <br/> 换行） */
+    title: React.ReactNode;
+    /** 位置 */
+    placement?: TooltipPlacement;
+    /** 触发方式 */
+    trigger?: TooltipTrigger;
+    /** 视觉风格：default 标准矩形 / island 动森有机气泡 */
+    variant?: TooltipVariant;
+    /** 是否显示边框（含箭头描边）；island 开启后 SVG 沿有机路径描边 */
+    bordered?: boolean;
+    /** 子元素（触发器） */
+    children: React.ReactElement;
+    /** 自定义类名 */
+    className?: string;
+    /** 自定义样式 */
+    style?: React.CSSProperties;
+}
+
+export const Tooltip: React.FC<TooltipProps> = ({
+    title,
+    placement = 'top',
+    trigger = 'hover',
+    variant = 'default',
+    bordered = true,
+    children,
+    className,
+    style,
+}) => {
+    const [visible, setVisible] = useState(false);
+    const timerRef = useRef<ReturnType<typeof setTimeout>>();
+    const clipId = `animal-tooltip-clip-${useId().replace(/:/g, '')}`;
+
+    const show = useCallback(() => {
+        clearTimeout(timerRef.current);
+        setVisible(true);
+    }, []);
+
+    const hide = useCallback(() => {
+        timerRef.current = setTimeout(() => setVisible(false), 100);
+    }, []);
+
+    useEffect(() => () => clearTimeout(timerRef.current), []);
+
+    const child = React.Children.only(children);
+
+    const triggerProps: Record<string, unknown> = {};
+
+    if (trigger === 'hover') {
+        triggerProps.onMouseEnter = (e: React.MouseEvent) => {
+            show();
+            (child.props as any).onMouseEnter?.(e);
+        };
+        triggerProps.onMouseLeave = (e: React.MouseEvent) => {
+            hide();
+            (child.props as any).onMouseLeave?.(e);
+        };
+    } else if (trigger === 'focus') {
+        triggerProps.onFocus = (e: React.FocusEvent) => {
+            show();
+            (child.props as any).onFocus?.(e);
+        };
+        triggerProps.onBlur = (e: React.FocusEvent) => {
+            hide();
+            (child.props as any).onBlur?.(e);
+        };
+    } else if (trigger === 'click') {
+        triggerProps.onClick = (e: React.MouseEvent) => {
+            setVisible((v) => !v);
+            (child.props as any).onClick?.(e);
+        };
+    }
+
+    const placementClass = styles[placement.replace(/-/g, '_')];
+    const isIsland = variant === 'island';
+
+    return (
+        <div
+            className={classNames(styles.tooltipWrapper, className)}
+            style={style}
+        >
+            {React.cloneElement(child, triggerProps)}
+            <div
+                className={classNames(
+                    styles.tooltip,
+                    placementClass,
+                    isIsland && styles.island,
+                    bordered ? styles.bordered : styles.borderless,
+                    { [styles.visible]: visible }
+                )}
+                role="tooltip"
+                aria-hidden={!visible}
+                onMouseEnter={trigger === 'hover' ? show : undefined}
+                onMouseLeave={trigger === 'hover' ? hide : undefined}
+            >
+                {isIsland ? (
+                    <>
+                        <div className={styles.islandBody}>
+                            <IslandClipDef id={clipId} />
+                            {bordered && <IslandShapeSvg />}
+                            <div
+                                className={styles.islandContent}
+                                style={{ clipPath: `url(#${clipId})` }}
+                            >
+                                <div className={styles.content}>{title}</div>
+                            </div>
+                        </div>
+                        <span className={styles.tail} aria-hidden />
+                    </>
+                ) : (
+                    <div className={styles.content}>{title}</div>
+                )}
+            </div>
+        </div>
+    );
+};
+
+Tooltip.displayName = 'Tooltip';

--- a/src/components/Tooltip/index.ts
+++ b/src/components/Tooltip/index.ts
@@ -1,0 +1,2 @@
+export { Tooltip } from './Tooltip';
+export type { TooltipProps, TooltipPlacement, TooltipTrigger, TooltipVariant } from './Tooltip';

--- a/src/components/Tooltip/tooltip.module.less
+++ b/src/components/Tooltip/tooltip.module.less
@@ -1,0 +1,526 @@
+// ============================================
+// Tooltip — Animal Island Style
+// ============================================
+@import '../../styles/variables.less';
+
+@tooltip-bg: rgb(247, 243, 223);
+@tooltip-border: #c4b89e;
+@tooltip-gap: 10px;
+@tooltip-arrow-size: 8px;
+@island-arrow-size: 10px;
+
+.tooltipWrapper {
+    position: relative;
+    display: inline-flex;
+    vertical-align: middle;
+    font-family: @font-family;
+}
+
+.tooltip {
+    position: absolute;
+    z-index: 100;
+    box-sizing: border-box;
+    // 修复 CJK 文本在 absolute + left:50% 下 shrink-to-fit 塌缩为单字宽
+    width: max-content;
+    max-width: 240px;
+    padding: 6px 12px;
+    background: @tooltip-bg;
+    border-radius: @border-radius-sm;
+    box-shadow: @shadow-base;
+    color: #725d42;
+    font-size: @font-size-sm;
+    font-weight: 500;
+    line-height: 1.5;
+    letter-spacing: 0.01em;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity @motion-duration-base @motion-ease,
+        transform @motion-duration-base @motion-ease;
+
+    &.visible {
+        opacity: 1;
+        pointer-events: auto;
+    }
+
+    &::after {
+        content: '';
+        position: absolute;
+        width: @tooltip-arrow-size;
+        height: @tooltip-arrow-size;
+        background: @tooltip-bg;
+        border-radius: 2px;
+    }
+}
+
+.content {
+    position: relative;
+    z-index: 1;
+    white-space: pre-line;
+    word-break: break-word;
+}
+
+// ---------- Border config ----------
+.tooltip:not(.island).bordered {
+    border: @border-width solid @tooltip-border;
+}
+
+.tooltip.borderless:not(.island)::after {
+    border: none !important;
+}
+
+// ---------- Island variant — 动森有机气泡 ----------
+.island {
+    background: transparent;
+    border: none;
+    box-shadow: none;
+    padding: 0;
+    max-width: 280px;
+
+    &::after {
+        display: none;
+    }
+}
+
+.islandBody {
+    position: relative;
+    width: max-content;
+    max-width: 280px;
+}
+
+.islandSvg {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    display: block;
+    pointer-events: none;
+    z-index: 0;
+}
+
+.islandContent {
+    position: relative;
+    z-index: 1;
+    padding: 12px 20px;
+
+    .content {
+        font-weight: 600;
+        line-height: 1.55;
+        text-align: center;
+    }
+}
+
+.island.bordered .islandBody {
+    padding: 2px;
+    filter: drop-shadow(0 4px 14px rgba(121, 79, 39, 0.14));
+}
+
+.island.bordered .islandContent {
+    background: transparent;
+}
+
+.island.borderless .islandContent {
+    background: @tooltip-bg;
+    filter: drop-shadow(0 4px 14px rgba(121, 79, 39, 0.14));
+}
+
+.tail {
+    position: absolute;
+    z-index: 2;
+    pointer-events: none;
+}
+
+// island 无边框：圆点指示
+.island.borderless .tail {
+    width: 14px;
+    height: 14px;
+    background: @tooltip-bg;
+    border-radius: 50%;
+}
+
+.island.borderless.top .tail {
+    bottom: -5px;
+    left: 50%;
+    transform: translateX(-50%);
+}
+
+.island.borderless.top_start .tail {
+    bottom: -5px;
+    left: 20px;
+}
+
+.island.borderless.top_end .tail {
+    bottom: -5px;
+    right: 20px;
+}
+
+.island.borderless.bottom .tail {
+    top: -5px;
+    left: 50%;
+    transform: translateX(-50%);
+}
+
+.island.borderless.bottom_start .tail {
+    top: -5px;
+    left: 20px;
+}
+
+.island.borderless.bottom_end .tail {
+    top: -5px;
+    right: 20px;
+}
+
+.island.borderless.left .tail {
+    right: -5px;
+    top: 50%;
+    transform: translateY(-50%);
+}
+
+.island.borderless.left_start .tail {
+    right: -5px;
+    top: 16px;
+}
+
+.island.borderless.left_end .tail {
+    right: -5px;
+    bottom: 16px;
+}
+
+.island.borderless.right .tail {
+    left: -5px;
+    top: 50%;
+    transform: translateY(-50%);
+}
+
+.island.borderless.right_start .tail {
+    left: -5px;
+    top: 16px;
+}
+
+.island.borderless.right_end .tail {
+    left: -5px;
+    bottom: 16px;
+}
+
+// island 有边框：菱形箭头（与 default 一致，方向更清晰）
+.island.bordered .tail {
+    width: @island-arrow-size;
+    height: @island-arrow-size;
+    background: @tooltip-bg;
+    border-radius: 2px;
+}
+
+.island.bordered.top .tail {
+    bottom: -5px;
+    left: 50%;
+    transform: translateX(-50%) rotate(45deg);
+    border-right: @border-width solid @tooltip-border;
+    border-bottom: @border-width solid @tooltip-border;
+}
+
+.island.bordered.top_start .tail {
+    bottom: -5px;
+    left: 20px;
+    transform: rotate(45deg);
+    border-right: @border-width solid @tooltip-border;
+    border-bottom: @border-width solid @tooltip-border;
+}
+
+.island.bordered.top_end .tail {
+    bottom: -5px;
+    right: 20px;
+    transform: rotate(45deg);
+    border-right: @border-width solid @tooltip-border;
+    border-bottom: @border-width solid @tooltip-border;
+}
+
+.island.bordered.bottom .tail {
+    top: -5px;
+    left: 50%;
+    transform: translateX(-50%) rotate(45deg);
+    border-top: @border-width solid @tooltip-border;
+    border-left: @border-width solid @tooltip-border;
+}
+
+.island.bordered.bottom_start .tail {
+    top: -5px;
+    left: 20px;
+    transform: rotate(45deg);
+    border-top: @border-width solid @tooltip-border;
+    border-left: @border-width solid @tooltip-border;
+}
+
+.island.bordered.bottom_end .tail {
+    top: -5px;
+    right: 20px;
+    transform: rotate(45deg);
+    border-top: @border-width solid @tooltip-border;
+    border-left: @border-width solid @tooltip-border;
+}
+
+.island.bordered.left .tail {
+    right: -5px;
+    top: 50%;
+    transform: translateY(-50%) rotate(45deg);
+    border-top: @border-width solid @tooltip-border;
+    border-right: @border-width solid @tooltip-border;
+}
+
+.island.bordered.left_start .tail {
+    right: -5px;
+    top: 16px;
+    transform: rotate(45deg);
+    border-top: @border-width solid @tooltip-border;
+    border-right: @border-width solid @tooltip-border;
+}
+
+.island.bordered.left_end .tail {
+    right: -5px;
+    bottom: 16px;
+    transform: rotate(45deg);
+    border-top: @border-width solid @tooltip-border;
+    border-right: @border-width solid @tooltip-border;
+}
+
+.island.bordered.right .tail {
+    left: -5px;
+    top: 50%;
+    transform: translateY(-50%) rotate(45deg);
+    border-bottom: @border-width solid @tooltip-border;
+    border-left: @border-width solid @tooltip-border;
+}
+
+.island.bordered.right_start .tail {
+    left: -5px;
+    top: 16px;
+    transform: rotate(45deg);
+    border-bottom: @border-width solid @tooltip-border;
+    border-left: @border-width solid @tooltip-border;
+}
+
+.island.bordered.right_end .tail {
+    left: -5px;
+    bottom: 16px;
+    transform: rotate(45deg);
+    border-bottom: @border-width solid @tooltip-border;
+    border-left: @border-width solid @tooltip-border;
+}
+
+// ---------- Top ----------
+.top {
+    bottom: calc(100% + @tooltip-gap);
+    left: 50%;
+    transform: translateX(-50%) translateY(4px);
+
+    &.visible {
+        transform: translateX(-50%) translateY(0);
+    }
+
+    &::after {
+        bottom: -5px;
+        left: 50%;
+        transform: translateX(-50%) rotate(45deg);
+        border-right: @border-width solid @tooltip-border;
+        border-bottom: @border-width solid @tooltip-border;
+    }
+}
+
+.top_start {
+    bottom: calc(100% + @tooltip-gap);
+    left: 0;
+    transform: translateY(4px);
+
+    &.visible {
+        transform: translateY(0);
+    }
+
+    &::after {
+        bottom: -5px;
+        left: 16px;
+        transform: rotate(45deg);
+        border-right: @border-width solid @tooltip-border;
+        border-bottom: @border-width solid @tooltip-border;
+    }
+}
+
+.top_end {
+    bottom: calc(100% + @tooltip-gap);
+    right: 0;
+    transform: translateY(4px);
+
+    &.visible {
+        transform: translateY(0);
+    }
+
+    &::after {
+        bottom: -5px;
+        right: 16px;
+        transform: rotate(45deg);
+        border-right: @border-width solid @tooltip-border;
+        border-bottom: @border-width solid @tooltip-border;
+    }
+}
+
+// ---------- Bottom ----------
+.bottom {
+    top: calc(100% + @tooltip-gap);
+    left: 50%;
+    transform: translateX(-50%) translateY(-4px);
+
+    &.visible {
+        transform: translateX(-50%) translateY(0);
+    }
+
+    &::after {
+        top: -5px;
+        left: 50%;
+        transform: translateX(-50%) rotate(45deg);
+        border-top: @border-width solid @tooltip-border;
+        border-left: @border-width solid @tooltip-border;
+    }
+}
+
+.bottom_start {
+    top: calc(100% + @tooltip-gap);
+    left: 0;
+    transform: translateY(-4px);
+
+    &.visible {
+        transform: translateY(0);
+    }
+
+    &::after {
+        top: -5px;
+        left: 16px;
+        transform: rotate(45deg);
+        border-top: @border-width solid @tooltip-border;
+        border-left: @border-width solid @tooltip-border;
+    }
+}
+
+.bottom_end {
+    top: calc(100% + @tooltip-gap);
+    right: 0;
+    transform: translateY(-4px);
+
+    &.visible {
+        transform: translateY(0);
+    }
+
+    &::after {
+        top: -5px;
+        right: 16px;
+        transform: rotate(45deg);
+        border-top: @border-width solid @tooltip-border;
+        border-left: @border-width solid @tooltip-border;
+    }
+}
+
+// ---------- Left ----------
+.left {
+    right: calc(100% + @tooltip-gap);
+    top: 50%;
+    transform: translateY(-50%) translateX(4px);
+
+    &.visible {
+        transform: translateY(-50%) translateX(0);
+    }
+
+    &::after {
+        right: -5px;
+        top: 50%;
+        transform: translateY(-50%) rotate(45deg);
+        border-top: @border-width solid @tooltip-border;
+        border-right: @border-width solid @tooltip-border;
+    }
+}
+
+.left_start {
+    right: calc(100% + @tooltip-gap);
+    top: 0;
+    transform: translateX(4px);
+
+    &.visible {
+        transform: translateX(0);
+    }
+
+    &::after {
+        right: -5px;
+        top: 12px;
+        transform: rotate(45deg);
+        border-top: @border-width solid @tooltip-border;
+        border-right: @border-width solid @tooltip-border;
+    }
+}
+
+.left_end {
+    right: calc(100% + @tooltip-gap);
+    bottom: 0;
+    transform: translateX(4px);
+
+    &.visible {
+        transform: translateX(0);
+    }
+
+    &::after {
+        right: -5px;
+        bottom: 12px;
+        transform: rotate(45deg);
+        border-top: @border-width solid @tooltip-border;
+        border-right: @border-width solid @tooltip-border;
+    }
+}
+
+// ---------- Right ----------
+.right {
+    left: calc(100% + @tooltip-gap);
+    top: 50%;
+    transform: translateY(-50%) translateX(-4px);
+
+    &.visible {
+        transform: translateY(-50%) translateX(0);
+    }
+
+    &::after {
+        left: -5px;
+        top: 50%;
+        transform: translateY(-50%) rotate(45deg);
+        border-bottom: @border-width solid @tooltip-border;
+        border-left: @border-width solid @tooltip-border;
+    }
+}
+
+.right_start {
+    left: calc(100% + @tooltip-gap);
+    top: 0;
+    transform: translateX(-4px);
+
+    &.visible {
+        transform: translateX(0);
+    }
+
+    &::after {
+        left: -5px;
+        top: 12px;
+        transform: rotate(45deg);
+        border-bottom: @border-width solid @tooltip-border;
+        border-left: @border-width solid @tooltip-border;
+    }
+}
+
+.right_end {
+    left: calc(100% + @tooltip-gap);
+    bottom: 0;
+    transform: translateX(-4px);
+
+    &.visible {
+        transform: translateX(0);
+    }
+
+    &::after {
+        left: -5px;
+        bottom: 12px;
+        transform: rotate(45deg);
+        border-bottom: @border-width solid @tooltip-border;
+        border-left: @border-width solid @tooltip-border;
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,12 @@ export type { TabsProps, TabItem } from './components/Tabs';
 export { Checkbox } from './components/Checkbox';
 export type { CheckboxProps, CheckboxOption, CheckboxSize } from './components/Checkbox';
 
+export { Radio } from './components/Radio';
+export type { RadioProps, RadioOption, RadioSize } from './components/Radio';
+
+export { Tooltip } from './components/Tooltip';
+export type { TooltipProps, TooltipPlacement, TooltipTrigger, TooltipVariant } from './components/Tooltip';
+
 export { CodeBlock } from './components/CodeBlock';
 export type { CodeBlockProps } from './components/CodeBlock';
 


### PR DESCRIPTION
## Summary

新增两个动森风格基础组件 **Radio** 与 **Tooltip**，并补齐 Demo 文档、侧边栏入口与库导出。

### Radio 单选框

- 支持受控 / 非受控（`value` / `defaultValue`）
- 三种尺寸：`small` | `middle` | `large`
- 水平 / 垂直排列，单项或整组禁用
- 键盘导航：方向键、Home / End、Space / Enter
- Roving tabindex + `role="radiogroup"` / `role="radio"`
- 受控 `value` 变化时同步焦点索引；禁用项带 `aria-disabled`

### Tooltip 气泡提示

- **12 个方向**：`top` / `bottom` / `left` / `right` 及 `-start` / `-end` 变体
- **三种触发**：`hover` | `focus` | `click`
- **两种风格**：`default` 标准矩形 / `island` 动森有机气泡（与 Modal 同款 clip-path）
- **`bordered` 可配置**：矩形描边 + 菱形箭头；island 模式用 SVG path 沿不规则轮廓描边
- 多行内容支持（`\n` 与 `<br/>`）；隐藏时 `aria-hidden`

### 其他变更

- `src/index.ts` 导出组件及类型
- Demo：`App.tsx` 菜单、`ComponentPage.tsx` / `pageInfo.ts` 注册与描述
- 各组件 Demo 含示例、`ApiTable`、`CodeBlock`

## Test plan

- [ ] `npm run build` 通过
- [ ] `npm run build:demo` 通过
- [ ] `npm run dev`，访问 `#/radio`：受控切换、垂直排列、禁用项、三种尺寸、方向键导航
- [ ] 访问 `#/tooltip`：12 方向吸附、hover / click / focus 触发
- [ ] Tooltip `variant="island"` + `bordered` / `bordered={false}` 视觉对比
- [ ] Tooltip 多行文本与长文本自动换行
- [ ] 从 `animal-island-ui` 导入 `Radio` / `Tooltip` 类型正常