### PR TITLE
feat(Modal): Add maskStyle property to support custom mask styling

### DIFF
--- a/demo/ComponentPage.tsx
+++ b/demo/ComponentPage.tsx
@@ -245,6 +245,12 @@ const MODAL_API: ApiRow[] = [
         type: 'boolean',
         defaultVal: 'true',
     },
+    {
+        prop: 'maskStyle',
+        desc: '遮罩层自定义样式',
+        type: 'CSSProperties',
+        defaultVal: '-',
+    },
 ];
 
 const CARD_API: ApiRow[] = [
@@ -899,6 +905,7 @@ const ModalDemo: React.FC = () => {
     const [titleModalOpen, setTitleModalOpen] = useState(false);
     const [customFooterOpen, setCustomFooterOpen] = useState(false);
     const [noTypewriterOpen, setNoTypewriterOpen] = useState(false);
+    const [lightMaskOpen, setLightMaskOpen] = useState(false);
     return (
         <div style={sectionStyle}>
             <div style={sectionTitleStyle}>
@@ -919,6 +926,12 @@ const ModalDemo: React.FC = () => {
                 <div style={S.row}>
                     <Button type="primary" onClick={() => setNoTypewriterOpen(true)}>
                         关闭打字机效果
+                    </Button>
+                </div>
+                <div style={labelStyle}>自定义遮罩样式</div>
+                <div style={S.row}>
+                    <Button type="primary" onClick={() => setLightMaskOpen(true)}>
+                        浅色遮罩
                     </Button>
                 </div>
             </div>
@@ -971,6 +984,15 @@ const ModalDemo: React.FC = () => {
             >
                 明天天气晴朗，气温 20-28°C，适合外出活动！
             </Modal>
+            <Modal
+                open={lightMaskOpen}
+                title="浅色遮罩"
+                onClose={() => setLightMaskOpen(false)}
+                onOk={() => setLightMaskOpen(false)}
+                maskStyle={{ background: 'rgba(0, 0, 0, 0.08)' }}
+            >
+                这是一个浅色遮罩的弹窗，遮罩几乎透明。
+            </Modal>
             <CodeBlock
                 code={`import React, { useState } from 'react';
 import { Button, Modal } from 'animal-island-ui';
@@ -1002,6 +1024,11 @@ const App = () => {
             {/* 关闭打字机效果 */}
             <Modal open={open} typewriter={false}>
                 直接显示全部内容
+            </Modal>
+
+            {/* 自定义遮罩样式 */}
+            <Modal open={open} maskStyle={{ background: 'rgba(0, 0, 0, 0.08)' }}>
+                浅色遮罩
             </Modal>
         </div>
     );
@@ -1310,7 +1337,7 @@ export const PAGE_INFO: Record<string, { title: string; desc: string }> = {
     },
     modal: {
         title: 'Modal 弹窗',
-        desc: '模态弹窗组件 — SVG 有机形状裁切、支持标题、关闭按钮、自定义 Footer、ESC / 遮罩关闭',
+        desc: '模态弹窗组件 — SVG 有机形状裁切、支持标题、关闭按钮、自定义 Footer、ESC / 遮罩关闭、自定义遮罩样式',
     },
     typewriter: {
         title: 'Typewriter 打字机',

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -36,6 +36,8 @@ export interface ModalProps {
     typeSpeed?: number;
     /** 是否启用打字机效果, 默认 true */
     typewriter?: boolean;
+    /** 遮罩层自定义样式 */
+    maskStyle?: React.CSSProperties;
 }
 
 export const Modal: React.FC<ModalProps> = ({
@@ -50,6 +52,7 @@ export const Modal: React.FC<ModalProps> = ({
     className,
     typeSpeed = 80,
     typewriter = true,
+    maskStyle,
 }) => {
     // 每次 open 变为 true 时重启打字机
     const [playKey, setPlayKey] = useState(0);
@@ -100,7 +103,7 @@ export const Modal: React.FC<ModalProps> = ({
 
     const modalContent = (
         <Cursor>
-            <div className={styles.mask} onClick={handleMaskClick}>
+            <div className={styles.mask} style={maskStyle} onClick={handleMaskClick}>
                 <div
                     className={[styles.modal, className].filter(Boolean).join(' ')}
                     style={{ width }}

--- a/src/components/Modal/modal.module.less
+++ b/src/components/Modal/modal.module.less
@@ -8,7 +8,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    background: rgba(0, 0, 0, 0.35);
+    background: var(--animal-mask-bg);
     animation: animal-fade-in 0.25s ease;
 }
 

--- a/src/styles/themes/default.less
+++ b/src/styles/themes/default.less
@@ -36,6 +36,9 @@
     --animal-bg-color-secondary: @bg-color-secondary;
     --animal-bg-color-disabled: @bg-color-disabled;
 
+    // Overlay
+    --animal-mask-bg: @mask-bg;
+
     // Typography
     --animal-font-family: @font-family;
     --animal-font-size-sm: @font-size-sm;

--- a/src/styles/variables.less
+++ b/src/styles/variables.less
@@ -37,6 +37,9 @@
 @bg-color-secondary: #f0e8d8;
 @bg-color-disabled: #f0ece2;
 
+// ---------- Overlay ----------
+@mask-bg: rgba(0, 0, 0, 0.35);
+
 // ---------- Typography ----------
 // 字体栈策略：
 //   1. Nunito                  - 拉丁字符主字体（已打入库）


### PR DESCRIPTION
feat(Modal): 新增maskStyle属性支持自定义遮罩样式

Modal Component Enhancement:
1. Added a global mask background CSS variable and bound it to the CSS variable system
2. Added a `maskStyle` property to the Modal component, allowing custom styles to be passed to the mask
3. Added a demo showcasing a light-colored mask on the example page
4. Updated the documentation to describe the new API parameter (`maskStyle`)

Modal组件增强：
1. 新增了全局遮罩背景CSS变量，并绑定到CSS变量系统
2. 为Modal组件新增了`maskStyle`属性，允许向遮罩层传递自定义样式
3. 在示例页面新增了浅色遮罩的演示demo
4. 更新了文档，说明新增的API参数(`maskStyle`)