### PR TITLE
fix(Input): clear 按钮触发完整 SyntheticEvent 而非假事件

### DIFF
--- a/src/components/Input/Input.test.tsx
+++ b/src/components/Input/Input.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import { Input, type InputProps } from './Input';
 import { setup } from '@test/utils';
 import { ControlledHost } from '@test/components';
@@ -109,4 +109,33 @@ describe('Input', () => {
             expect(screen.getByRole('button', { name: 'Clear' })).toBeInTheDocument();
         });
     });
+});
+
+it('Bug 复现: clear 触发的事件缺少 preventDefault 等 SyntheticEvent 方法', async () => {
+    const onChange = vi.fn();
+    render(<Input allowClear defaultValue="hello" name="username" onChange={onChange} />);
+    const clearBtn = screen.getByRole('button');
+    await act(async () => {
+        clearBtn.click();
+        await new Promise((r) => setTimeout(r, 0));
+    });
+    const eventArg = onChange.mock.calls[0][0];
+    // SyntheticEvent 应有的方法全部缺失
+    expect(typeof eventArg.preventDefault).toBe('function');
+    expect(typeof eventArg.stopPropagation).toBe('function');
+});
+
+it('Bug 复现: clear 触发的事件 target 只有 value，缺少真实 input 属性', async () => {
+    const onChange = vi.fn();
+    render(<Input allowClear defaultValue="hello" name="username" type="email" id="my-input" onChange={onChange} />);
+    const clearBtn = screen.getByRole('button');
+    await act(async () => {
+        clearBtn.click();
+        await new Promise((r) => setTimeout(r, 0));
+    });
+    const eventArg = onChange.mock.calls[0][0];
+    // 真实 input 的 ChangeEvent.target 应该带有这些属性
+    expect(eventArg.target.name).toBe('username');
+    expect(eventArg.target.type).toBe('email');
+    expect(eventArg.target.id).toBe('my-input');
 });

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+﻿import React, { useState, useCallback, useRef } from 'react';
 import styles from './input.module.less';
 
 export type InputSize = 'small' | 'middle' | 'large';
@@ -20,7 +20,7 @@ export interface InputProps extends Omit<React.InputHTMLAttributes<HTMLInputElem
     onChange?: React.ChangeEventHandler<HTMLInputElement>;
     /** 清除回调 */
     onClear?: () => void;
-    /** 清除按钮的无障碍标签，默认 "清除" */
+    /** 清除按钮的无障碍标签，默认"清除" */
     clearAriaLabel?: string;
 }
 
@@ -43,6 +43,7 @@ export const Input: React.FC<InputProps> = ({
     const [innerValue, setInnerValue] = useState(defaultValue ?? '');
     const isControlled = value !== undefined;
     const currentValue = isControlled ? value : innerValue;
+    const inputRef = useRef<HTMLInputElement>(null);
 
     const handleChange: React.ChangeEventHandler<HTMLInputElement> = useCallback(
         (e) => {
@@ -55,15 +56,19 @@ export const Input: React.FC<InputProps> = ({
     const handleClear = useCallback(() => {
         if (!isControlled) setInnerValue('');
         onClear?.();
-        // 触发 onChange 模拟清空
-        const nativeEvent = new Event('input', { bubbles: true });
-        const fakeTarget = { value: '' } as HTMLInputElement;
-        onChange?.({
-            target: fakeTarget,
-            currentTarget: fakeTarget,
-            nativeEvent,
-        } as React.ChangeEvent<HTMLInputElement>);
-    }, [isControlled, onChange, onClear]);
+        // 通过 dispatchEvent 产生真实的 React SyntheticEvent
+        // 避免手搓假事件导致的 preventDefault/stopPropagation 缺失和 target 属性残缺
+        const input = inputRef.current;
+        if (input) {
+            const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+                window.HTMLInputElement.prototype,
+                'value'
+            )?.set;
+            nativeInputValueSetter?.call(input, '');
+            const event = new Event('input', { bubbles: true });
+            input.dispatchEvent(event);
+        }
+    }, [isControlled, onClear]);
 
     const wrapperCls = [
         styles.wrapper,
@@ -80,6 +85,7 @@ export const Input: React.FC<InputProps> = ({
         <span className={wrapperCls}>
             {prefix && <span className={styles.prefix}>{prefix}</span>}
             <input
+                ref={inputRef}
                 className={styles.input}
                 disabled={disabled}
                 value={currentValue}


### PR DESCRIPTION
点击 clear 按钮时，旧代码手搓了一个假事件对象传给 onChange，
该对象缺少 preventDefault / stopPropagation 方法，
且 target 只有 { value: '' }，没有真实 input 元素的 name / type / id 等属性， 导致依赖 React SyntheticEvent 标准接口的消费方（如表单校验库）运行异常。

改用 dispatchEvent(new Event('input')) 在真实 DOM input 上发射原生事件， 让 React 事件系统自动创建完整的 SyntheticEvent，所有属性和方法均正确可用。