### PR TITLE
Unify demo component sidebar navigation

### DIFF
--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -11,7 +11,7 @@ import '@fontsource/noto-sans-sc/chinese-simplified-400.css';
 import '@fontsource/noto-sans-sc/chinese-simplified-500.css';
 import '@fontsource/noto-sans-sc/chinese-simplified-700.css';
 import HomePage from './HomePage';
-import { PAGE_INFO } from './pageInfo';
+import { COMPONENT_NAV_SECTIONS, PAGE_INFO } from './pageInfo';
 import { useIsMobile } from './tools';
 
 // Lazy-load ComponentPage so homepage does not pull in every demo on initial load
@@ -35,61 +35,6 @@ const useHash = () => {
 
     return { hash, navigate };
 };
-
-interface MenuItemChild {
-    key: string;
-    label: string;
-    isNew?: boolean;
-}
-
-interface MenuItem {
-    key: string;
-    label: string;
-    children?: MenuItemChild[];
-}
-
-// ============================================
-// Menu config
-// ============================================
-const MENU_ITEMS: MenuItem[] = [
-    {
-        key: 'cat-basic',
-        label: '── 基础组件 ──',
-        children: [
-            { key: 'title', label: 'Title 标题', isNew: true },
-            { key: 'button', label: 'Button 按钮' },
-            { key: 'input', label: 'Input 输入框' },
-            { key: 'switch', label: 'Switch 开关' },
-            { key: 'card', label: 'Card 卡片' },
-            { key: 'collapse', label: 'Collapse 折叠面板' },
-            { key: 'cursor', label: 'Cursor 光标' },
-            { key: 'modal', label: 'Modal 弹窗' },
-            { key: 'typewriter', label: 'Typewriter 打字机' },
-            { key: 'divider-comp', label: 'Divider 分割线' },
-            { key: 'icon', label: 'Icon 图标' },
-            { key: 'select', label: 'Select 选择器' },
-            { key: 'checkbox', label: 'Checkbox 多选框' },
-            { key: 'radio', label: 'Radio 单选框' },
-            { key: 'tooltip', label: 'Tooltip 气泡提示' },
-            { key: 'tabs', label: 'Tabs 标签页' },
-            { key: 'footer', label: 'Footer 页脚' },
-            { key: 'codeblock', label: 'CodeBlock 代码高亮' },
-            { key: 'loading', label: 'Loading 加载', isNew: true },
-            { key: 'table', label: 'Table 表格' },
-            { key: 'form', label: 'Form 表单', isNew: true },
-        ],
-    },
-    {
-        key: 'cat-complex',
-        label: '── 复杂组件 ──',
-        children: [
-            { key: 'wallet', label: 'Wallet 钱包', isNew: true },
-            { key: 'time', label: 'Time 时间' },
-            { key: 'phone', label: 'Phone 手机' },
-            { key: 'wedding-invitation', label: 'Wedding 婚礼请柬', isNew: true },
-        ],
-    },
-];
 
 // ============================================
 // Shared styles
@@ -189,62 +134,43 @@ const SidebarContent: React.FC<{
             集合啦！Animal
         </div>
         <nav style={S.menuList}>
-            {MENU_ITEMS.map((item) => {
-                if (item.children) {
-                    return (
-                        <div key={item.key}>
-                            <div
-                                style={{
-                                    padding: '12px 16px 4px',
-                                    fontSize: 11,
-                                    color: '#a0936e',
-                                    fontWeight: 600,
-                                    letterSpacing: 0.5,
-                                }}
-                            >
-                                {item.label}
-                            </div>
-                            {item.children.map((child) => (
-                                <div
-                                    key={child.key}
-                                    style={S.menuItem(activeKey === child.key)}
-                                    onClick={() => onNavigate(`/${child.key}`)}
-                                    onMouseEnter={(e) => {
-                                        if (activeKey !== child.key) e.currentTarget.style.background = '#d6dff0';
-                                    }}
-                                    onMouseLeave={(e) => {
-                                        if (activeKey !== child.key) e.currentTarget.style.background = 'transparent';
-                                    }}
-                                >
-                                    <span
-                                        style={{
-                                            color: activeKey === child.key ? '#fff' : '#8a7b66',
-                                        }}
-                                    >
-                                        {child.label}
-                                    </span>
-                                    {child.isNew && <span style={S.menuBadge(activeKey === child.key)}>NEW</span>}
-                                </div>
-                            ))}
-                        </div>
-                    );
-                }
-                return (
+            {COMPONENT_NAV_SECTIONS.map((item) => (
+                <div key={item.key}>
                     <div
-                        key={item.key}
-                        style={S.menuItem(activeKey === item.key)}
-                        onClick={() => onNavigate(`/${item.key}`)}
-                        onMouseEnter={(e) => {
-                            if (activeKey !== item.key) e.currentTarget.style.background = '#d6dff0';
-                        }}
-                        onMouseLeave={(e) => {
-                            if (activeKey !== item.key) e.currentTarget.style.background = 'transparent';
+                        style={{
+                            padding: '12px 16px 4px',
+                            fontSize: 11,
+                            color: '#a0936e',
+                            fontWeight: 600,
+                            letterSpacing: 0.5,
                         }}
                     >
-                        <span style={{ color: activeKey === item.key ? '#fff' : '#8a7b66' }}>{item.label}</span>
+                        {item.label}
                     </div>
-                );
-            })}
+                    {item.children.map((child) => (
+                        <div
+                            key={child.key}
+                            style={S.menuItem(activeKey === child.key)}
+                            onClick={() => onNavigate(`/${child.key}`)}
+                            onMouseEnter={(e) => {
+                                if (activeKey !== child.key) e.currentTarget.style.background = '#d6dff0';
+                            }}
+                            onMouseLeave={(e) => {
+                                if (activeKey !== child.key) e.currentTarget.style.background = 'transparent';
+                            }}
+                        >
+                            <span
+                                style={{
+                                    color: activeKey === child.key ? '#fff' : '#8a7b66',
+                                }}
+                            >
+                                {child.label}
+                            </span>
+                            {child.isNew && <span style={S.menuBadge(activeKey === child.key)}>NEW</span>}
+                        </div>
+                    ))}
+                </div>
+            ))}
         </nav>
     </>
 );

--- a/demo/ComponentPage.tsx
+++ b/demo/ComponentPage.tsx
@@ -11,6 +11,7 @@ import {
     CodeBlock,
     demoDashedBoxStyle,
 } from './tools';
+import { PAGE_INFO } from './pageInfo';
 import TimeDemo from './components/Time';
 import PhoneDemo from './components/Phone';
 import FooterDemo from './components/Footer';
@@ -1309,111 +1310,8 @@ export default App;`}
 };
 
 // ============================================
-// Page info & mapping
+// Page mapping
 // ============================================
-export const PAGE_INFO: Record<string, { title: string; desc: string }> = {
-    button: {
-        title: 'Button 按钮',
-        desc: '按钮组件 — 支持 primary / dashed / text / link 等类型，danger / ghost / loading / disabled 状态，icon 图标，block 块级，三种尺寸',
-    },
-    input: {
-        title: 'Input 输入框',
-        desc: '输入框组件 — 支持三种尺寸、clearable 清除、prefix / suffix 前后缀、error / warning 校验状态、disabled 禁用',
-    },
-    switch: {
-        title: 'Switch 开关',
-        desc: '开关组件 — 支持受控 / 非受控、自定义文案、small 尺寸、loading 状态',
-    },
-    card: {
-        title: 'Card 卡片',
-        desc: '卡片容器组件 — 支持 default / title 两种类型，12 种 NookPhone 背景颜色',
-    },
-    collapse: {
-        title: 'Collapse 折叠面板',
-        desc: '折叠面板组件 — 支持展开/收起、默认展开、禁用状态',
-    },
-    cursor: {
-        title: 'Cursor 光标',
-        desc: '光标组件 — 自定义手指光标，支持自定义尺寸、点击动画',
-    },
-    time: {
-        title: 'Time 时间',
-        desc: '经典 HUD 风格的时间显示组件，实时更新时间',
-    },
-    phone: {
-        title: 'Phone 手机',
-        desc: '动森风格手机界面，包含对话框和背包功能',
-    },
-    footer: {
-        title: 'Footer 底部装饰',
-        desc: '页面底部装饰图片，支持树和海两种类型',
-    },
-    modal: {
-        title: 'Modal 弹窗',
-        desc: '模态弹窗组件 — SVG 有机形状裁切、支持标题、关闭按钮、自定义 Footer、ESC / 遮罩关闭、自定义遮罩样式',
-    },
-    typewriter: {
-        title: 'Typewriter 打字机',
-        desc: '打字机组件 — 按字符逐个显示文本，支持多行与 ReactNode 富内容，不改变原有样式',
-    },
-    'divider-comp': {
-        title: 'Divider 分割线',
-        desc: '分割线组件 — 装饰性分割线',
-    },
-    icon: {
-        title: 'Icon 图标',
-        desc: '图标组件 — 动森风格图标集，包含 10 个可爱图标，支持自定义尺寸',
-    },
-    select: {
-        title: 'Select 选择器',
-        desc: '下拉选择器组件 — 支持自定义选项列表，高亮当前选中项',
-    },
-    tabs: {
-        title: 'Tabs 标签页',
-        desc: '标签页组件 — 支持受控/非受控模式切换',
-    },
-    checkbox: {
-        title: 'Checkbox 多选框',
-        desc: '多选框组件 — 支持受控/非受控、水平/垂直排列、三种尺寸、禁用单项或全部禁用',
-    },
-    radio: {
-        title: 'Radio 单选框',
-        desc: '单选框组件 — 支持受控/非受控、水平/垂直排列、三种尺寸、禁用单项或全部禁用',
-    },
-    tooltip: {
-        title: 'Tooltip 气泡提示',
-        desc: '气泡提示组件 — 支持 12 个方向、hover/click/focus 三种触发，default/island 两种风格，bordered 边框可配置',
-    },
-    title: {
-        title: 'Title 标题',
-        desc: '装饰性标题组件 — cloud 云朵 / ribbon 飘带 两种风格，三种尺寸，适用于游戏化页面、活动 Banner 与场景分组',
-    },
-    codeblock: {
-        title: 'CodeBlock 代码高亮',
-        desc: '代码高亮组件 — 语法高亮显示，支持自定义样式和类名',
-    },
-    loading: {
-        title: 'Loading 加载',
-        desc: '动森风格小岛 Loading 动画组件，支持自定义样式和类名',
-    },
-    table: {
-        title: 'Table 表格',
-        desc: '数据表格组件，支持斑马纹、边框、加载状态等常用功能',
-    },
-    'wedding-invitation': {
-        title: 'WeddingInvitation 婚礼请柬',
-        desc: '动森风格婚礼请柬组件 — 内置叶子边角、飘散花瓣、心跳爱心、吉祥物头像，所有装饰均为内联 SVG，无需外部素材',
-    },
-    wallet: {
-        title: 'Wallet 钱包',
-        desc: '动森风格金币展示 — 奶油描边的橄榄黄胶囊 + 上凸钱袋图标，支持千分位格式化、自定义图标与三种尺寸',
-    },
-    form: {
-        title: 'Form 表单',
-        desc: '表单组件 — 支持 useForm 命令式实例、多种校验规则、三种布局（horizontal / vertical / inline）、labelCol / wrapperCol 网格',
-    },
-};
-
 const PAGES: Record<string, React.FC> = {
     button: ButtonDemo,
     input: InputDemo,

--- a/demo/HomePage.tsx
+++ b/demo/HomePage.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Card, Divider, Button, Switch, Collapse, Typewriter } from '../src';
+import { COMPONENT_NAV_ITEMS, PAGE_INFO } from './pageInfo';
 import { useIsMobile } from './tools';
 
 // ============================================
@@ -306,6 +307,12 @@ const S = {
 // ============================================
 // Data
 // ============================================
+const components = COMPONENT_NAV_ITEMS.map((item) => ({
+    key: item.key,
+    name: item.label,
+    desc: PAGE_INFO[item.key]?.desc ?? '组件文档与在线演示',
+}));
+
 const features = [
     {
         icon: 'nook1.svg',
@@ -314,8 +321,8 @@ const features = [
     },
     {
         icon: 'Property-Shopping.svg',
-        title: '24 个组件',
-        desc: 'Button / Input / Switch / Modal / Form / Table / Title / Tooltip / Typewriter / Card / Collapse / Cursor / Divider / Time / Phone / Footer / Icon / Checkbox / Select / Tabs / CodeBlock / Loading / Radio / WeddingInvitation',
+        title: `${components.length} 个组件文档`,
+        desc: components.map((item) => item.name.split(' ')[0]).join(' / '),
     },
     {
         icon: 'Property-Camera.svg',
@@ -327,48 +334,6 @@ const features = [
         title: '开箱即用',
         desc: 'ESM + CJS 双格式输出，TypeScript 类型声明完整',
     },
-];
-
-const components = [
-    {
-        key: 'button',
-        name: 'Button',
-        desc: '5 种类型、3 种尺寸、加载/危险/幽灵模式',
-    },
-    { key: 'input', name: 'Input', desc: '前后缀、一键清空、校验状态' },
-    {
-        key: 'form',
-        name: 'Form',
-        desc: '校验规则 / useForm 命令式 / 三种布局',
-    },
-    {
-        key: 'switch',
-        name: 'Switch',
-        desc: '受控/非受控、自定义文案、加载状态',
-    },
-    { key: 'checkbox', name: 'Checkbox', desc: '多选框组件，支持水平/垂直排列' },
-    {
-        key: 'select',
-        name: 'Select',
-        desc: '下拉选择器，支持搜索和禁用',
-    },
-    { key: 'tabs', name: 'Tabs', desc: '标签页组件，支持受控/非受控模式' },
-    { key: 'modal', name: 'Modal', desc: 'SVG 有机形状弹窗、ESC 关闭' },
-    {
-        key: 'typewriter',
-        name: 'Typewriter',
-        desc: '逐字打字机效果，支持多行与富内容',
-    },
-    { key: 'card', name: 'Card', desc: '默认/标题两种卡片风格' },
-    { key: 'collapse', name: 'Collapse', desc: 'FAQ 折叠面板、平滑展开动画' },
-    { key: 'cursor', name: 'Cursor', desc: '自定义手指光标，支持多种尺寸' },
-    { key: 'divider-comp', name: 'Divider', desc: '装饰性水平分割线' },
-    { key: 'icon', name: 'Icon', desc: 'SVG 图标库' },
-    { key: 'footer', name: 'Footer', desc: '页脚组件' },
-    { key: 'time', name: 'Time', desc: '可爱风格时间显示' },
-    { key: 'phone', name: 'Phone', desc: 'Phone 模拟器' },
-    { key: 'codeblock', name: 'CodeBlock', desc: '代码语法高亮组件' },
-    { key: 'loading', name: 'Loading', desc: '动森风格小岛加载动画' },
 ];
 
 // ============================================

--- a/demo/pageInfo.ts
+++ b/demo/pageInfo.ts
@@ -1,4 +1,58 @@
 // 独立的轻量页面元信息，供 App 等场景静态导入，避免拉入整个 ComponentPage bundle
+export interface ComponentNavItem {
+    key: string;
+    label: string;
+    isNew?: boolean;
+}
+
+export interface ComponentNavSection {
+    key: string;
+    label: string;
+    children: ComponentNavItem[];
+}
+
+export const COMPONENT_NAV_SECTIONS: ComponentNavSection[] = [
+    {
+        key: 'cat-basic',
+        label: '── 基础组件 ──',
+        children: [
+            { key: 'title', label: 'Title 标题', isNew: true },
+            { key: 'button', label: 'Button 按钮' },
+            { key: 'input', label: 'Input 输入框' },
+            { key: 'switch', label: 'Switch 开关' },
+            { key: 'card', label: 'Card 卡片' },
+            { key: 'collapse', label: 'Collapse 折叠面板' },
+            { key: 'cursor', label: 'Cursor 光标' },
+            { key: 'modal', label: 'Modal 弹窗' },
+            { key: 'typewriter', label: 'Typewriter 打字机' },
+            { key: 'divider-comp', label: 'Divider 分割线' },
+            { key: 'icon', label: 'Icon 图标' },
+            { key: 'select', label: 'Select 选择器' },
+            { key: 'checkbox', label: 'Checkbox 多选框' },
+            { key: 'radio', label: 'Radio 单选框' },
+            { key: 'tooltip', label: 'Tooltip 气泡提示' },
+            { key: 'tabs', label: 'Tabs 标签页' },
+            { key: 'footer', label: 'Footer 页脚' },
+            { key: 'codeblock', label: 'CodeBlock 代码高亮' },
+            { key: 'loading', label: 'Loading 加载', isNew: true },
+            { key: 'table', label: 'Table 表格' },
+            { key: 'form', label: 'Form 表单', isNew: true },
+        ],
+    },
+    {
+        key: 'cat-complex',
+        label: '── 复杂组件 ──',
+        children: [
+            { key: 'wallet', label: 'Wallet 钱包', isNew: true },
+            { key: 'time', label: 'Time 时间' },
+            { key: 'phone', label: 'Phone 手机' },
+            { key: 'wedding-invitation', label: 'Wedding 婚礼请柬', isNew: true },
+        ],
+    },
+];
+
+export const COMPONENT_NAV_ITEMS = COMPONENT_NAV_SECTIONS.flatMap((section) => section.children);
+
 export const PAGE_INFO: Record<string, { title: string; desc: string }> = {
     button: {
         title: 'Button 按钮',
@@ -56,6 +110,10 @@ export const PAGE_INFO: Record<string, { title: string; desc: string }> = {
         title: 'Select 选择器',
         desc: '下拉选择器组件 — 支持自定义选项列表，高亮当前选中项',
     },
+    tabs: {
+        title: 'Tabs 标签页',
+        desc: '标签页组件 — 支持受控/非受控模式切换',
+    },
     checkbox: {
         title: 'Checkbox 多选框',
         desc: '多选框组件 — 支持受控/非受控、水平/垂直排列、三种尺寸、禁用单项或全部禁用',
@@ -79,6 +137,10 @@ export const PAGE_INFO: Record<string, { title: string; desc: string }> = {
     loading: {
         title: 'Loading 加载',
         desc: '动森风格小岛 Loading 动画组件，支持自定义样式和类名',
+    },
+    table: {
+        title: 'Table 表格',
+        desc: '数据表格组件，支持斑马纹、边框、加载状态等常用功能',
     },
     'wedding-invitation': {
         title: 'WeddingInvitation 婚礼请柬',


### PR DESCRIPTION
## 变更内容

- 将 demo 组件导航清单集中到 `demo/pageInfo.ts`，侧边栏从统一清单渲染组件目录。
- 首页组件一览复用同一份组件清单，避免新增组件后首页和侧边栏不同步。
- 组件详情页复用 `demo/pageInfo.ts` 的页面元信息，并补齐 `Tabs`、`Table` 的标题与描述。

## 验证

- `npm run lint`
- `npm run build:demo`
- `npm run format:check`
- Playwright 检查桌面 `#/button` 侧边栏与移动端抽屉均展示组件目录。